### PR TITLE
出題がシャッフルされていない不具合を修正する

### DIFF
--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -25,9 +25,6 @@ class Quiz
     self.class.correct?(last_question, @answers.last)? :win : :lose
   end
 
-  def self.haha
-  end
-
   def fin?
     @questions.count == @questions.answers.count
   end

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -56,7 +56,8 @@ class Quiz
       with_project(@conditions[:project_id]).
       with_gender(@conditions[:gender]).
       with_joined_year(@conditions[:joined_year]).
-      pluck(:user_id)
+      pluck(:user_id).
+      shuffle
   end
 
   def self.correct?(user_profile, answer_text)

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -18,7 +18,7 @@ class UserProfile < ActiveRecord::Base
     where.not(user_id: user_id)
   }
   scope :with_image, -> {
-    joins(:profile_images).merge(ProfileImage.where.not(situation: nil))
+    joins(:profile_images).merge(ProfileImage.with_situation('normal'))
   }
   scope :with_group, -> (group_id) {
     where(group_id: group_id) if group_id.present?

--- a/app/views/quizzes/question.html.haml
+++ b/app/views/quizzes/question.html.haml
@@ -2,7 +2,7 @@
   = I18n.t('quiz.question.no_questions')
   = render 'start_form'
 - else
-  = image_tag @question.profile_image_url(:normal)
+  = image_tag @question.profile_image_url(:normal), id: "question_image", 'data-user-id' => "#{@question.user.id}"
   #main-message
     = I18n.t('quiz.question.who')
   = form_tag answer_quiz_path do

--- a/spec/factories/user_profiles.rb
+++ b/spec/factories/user_profiles.rb
@@ -12,7 +12,11 @@ FactoryGirl.define do
     end
 
     after(:create) do |user_profile, evaluator|
-      FactoryGirl.create :profile_image, user_profile_id: user_profile.id, situation: 'normal' if evaluator.profile_image
+      if evaluator.profile_image
+        FactoryGirl.create :profile_image, user_profile_id: user_profile.id, situation: 'normal'
+        FactoryGirl.create :profile_image, user_profile_id: user_profile.id, situation: 'correct'
+        FactoryGirl.create :profile_image, user_profile_id: user_profile.id, situation: 'incorrect'
+      end
     end
 
     trait :with_answer do

--- a/spec/features/quizees_spec.rb
+++ b/spec/features/quizees_spec.rb
@@ -51,10 +51,6 @@ feature 'Quiz', type: :feature do
           expect(page).to have_content question_user.user.name
           expect(page).to have_content question_user.answer_name
           expect(page).to have_content question_user.detail
-          # expect(page).to have_content gender
-          # expect(page).to have_content joined_year
-          # expect(page).to have_content group_name
-          # expect(page).to have_content project_name
         end
 
         context 'When the answer was correct' do

--- a/spec/features/quizees_spec.rb
+++ b/spec/features/quizees_spec.rb
@@ -74,7 +74,11 @@ feature 'クイズ', type: :feature do
         scenario 'questions are shuffled' do
           expect(question_user_ids).not_to eq question_user_ids.sort
         end
-      end
+
+        scenario 'different user is found per 1 question' do
+          expect(question_user_ids.uniq.size).to eq question_user_ids.size
+        end
+     end
 
       context '正解だった場合' do
         before do

--- a/spec/features/quizees_spec.rb
+++ b/spec/features/quizees_spec.rb
@@ -1,23 +1,22 @@
 require 'rails_helper'
 
-feature 'クイズ', type: :feature do
+feature 'Quiz', type: :feature do
   include_context 'login_as_user'
 
-  feature 'クイズを始める' do
+  feature 'Start' do
     before do
       visit new_quiz_path
     end
 
-    scenario 'クイズ開始フォームが表示される' do
+    scenario 'display starting form' do
       expect(page).to have_select('joined_year')
       expect(page).to have_select('project_id')
       expect(page).to have_select('group_id')
-      # expect(page).to have_field('review_mode')
       expect(page).to have_button I18n.t('quiz.new.start_quiz')
     end
 
-    context 'クイズを始めるボタンをクリックしたとき' do
-      scenario 'クイズが開始される' do
+    context 'When the user clicks start button' do
+      scenario 'the quiz starts' do
         click_button I18n.t('quiz.new.start_quiz')
         expect(current_path).to eq question_quiz_path
       end
@@ -25,7 +24,7 @@ feature 'クイズ', type: :feature do
   end
 
   # FIXME: ビューのテストにしかなってないのでなおす
-  feature 'クイズを進める' do
+  feature 'Answer' do
     let!(:users) { FactoryGirl.create_list :user_profile, 30 }
     let!(:question_user) { FactoryGirl.create :user_profile }
 
@@ -34,94 +33,96 @@ feature 'クイズ', type: :feature do
       click_button I18n.t('quiz.new.start_quiz')
     end
 
-    scenario '回答入力フォームが表示される' do
-      expect(page).to have_field('answer_name')
-      expect(page).to have_button I18n.t('quiz.question.submit')
-    end
-
-    feature 'クイズに回答する' do
-      before do
-        allow_any_instance_of(Quiz).to receive(:last_question).and_return(question_user)
+    feature 'To one question' do
+      scenario 'display answer form' do
+        expect(page).to have_field('answer_name')
+        expect(page).to have_button I18n.t('quiz.question.submit')
       end
 
-      scenario '問題となったユーザのプロフィールが表示される' do
-        fill_in 'answer_name', with: question_user.answer_name
-        click_button I18n.t('quiz.question.submit')
+      feature 'User challenges to a game and get result' do
+        before do
+          allow_any_instance_of(Quiz).to receive(:last_question).and_return(question_user)
+        end
 
-        expect(page).to have_content question_user.user.name
-        expect(page).to have_content question_user.answer_name
-        expect(page).to have_content question_user.detail
-        # expect(page).to have_content gender
-        # expect(page).to have_content joined_year
-        # expect(page).to have_content group_name
-        # expect(page).to have_content project_name
-      end
+        scenario 'display question user profile' do
+          fill_in 'answer_name', with: question_user.answer_name
+          click_button I18n.t('quiz.question.submit')
 
-      feature 'to many questions continuity' do
-        let(:question_user_ids) {
-          questions = []
+          expect(page).to have_content question_user.user.name
+          expect(page).to have_content question_user.answer_name
+          expect(page).to have_content question_user.detail
+          # expect(page).to have_content gender
+          # expect(page).to have_content joined_year
+          # expect(page).to have_content group_name
+          # expect(page).to have_content project_name
+        end
 
-          10.times do
-            questions.push find('#question_image')['data-user-id'].to_i
+        context 'When the answer was correct' do
+          before do
+            allow_any_instance_of(Quiz).to receive(:last_result).and_return(:win)
+          end
 
+          scenario 'display winning message' do
             fill_in 'answer_name', with: question_user.answer_name
             click_button I18n.t('quiz.question.submit')
-            click_button I18n.t('quiz.result.next')
+
+            expect(page).to have_content I18n.t('quiz.result.correct')
           end
-          questions
-        }
 
-        scenario 'questions are shuffled' do
-          expect(question_user_ids).not_to eq question_user_ids.sort
+          scenario 'display total correct num' do
+            fill_in 'answer_name', with: question_user.answer_name
+            click_button I18n.t('quiz.question.submit')
+
+            click_button I18n.t('quiz.result.next')
+            expect(page).to have_css('#total_correct', I18n.t('quiz.show.correct'))
+            expect(page).to have_css('#total_correct', text: '1')
+          end
         end
 
-        scenario 'different user is found per 1 question' do
-          expect(question_user_ids.uniq.size).to eq question_user_ids.size
-        end
-     end
+        context 'When the answer was incorrect' do
+          before do
+            allow_any_instance_of(Quiz).to receive(:last_result).and_return(:lose)
+          end
 
-      context '正解だった場合' do
-        before do
-          allow_any_instance_of(Quiz).to receive(:last_result).and_return(:win)
-        end
+          scenario 'display losing message' do
+            fill_in 'answer_name', with: question_user.answer_name
+            click_button I18n.t('quiz.question.submit')
 
-        scenario 'お祝いのメッセージが表示される' do
-          fill_in 'answer_name', with: question_user.answer_name
-          click_button I18n.t('quiz.question.submit')
+            expect(page).to have_content I18n.t('quiz.result.incorrect')
+          end
 
-          expect(page).to have_content I18n.t('quiz.result.correct')
-        end
+          scenario 'display total incorrect num' do
+            fill_in 'answer_name', with: question_user.answer_name
+            click_button I18n.t('quiz.question.submit')
 
-        scenario '正解数の合計が表示される' do
-          fill_in 'answer_name', with: question_user.answer_name
-          click_button I18n.t('quiz.question.submit')
-
-          click_button I18n.t('quiz.result.next')
-          expect(page).to have_css('#total_correct', I18n.t('quiz.show.correct'))
-          expect(page).to have_css('#total_correct', text: '1')
+            click_button I18n.t('quiz.result.next')
+            expect(page).to have_css('#total_incorrect', I18n.t('quiz.show.incorrect'))
+            expect(page).to have_css('#total_incorrect', text: '1')
+          end
         end
       end
+    end
 
-      context '不正解だった場合' do
-        before do
-          allow_any_instance_of(Quiz).to receive(:last_result).and_return(:lose)
-        end
+    feature 'To many questions continuity' do
+      let(:question_user_ids) {
+        questions = []
 
-        scenario 'お悔やみのメッセージが表示される' do
+        10.times do
+          questions.push find('#question_image')['data-user-id'].to_i
+
           fill_in 'answer_name', with: question_user.answer_name
           click_button I18n.t('quiz.question.submit')
-
-          expect(page).to have_content I18n.t('quiz.result.incorrect')
-        end
-
-        scenario '不正解数の合計が表示される' do
-          fill_in 'answer_name', with: question_user.answer_name
-          click_button I18n.t('quiz.question.submit')
-
           click_button I18n.t('quiz.result.next')
-          expect(page).to have_css('#total_incorrect', I18n.t('quiz.show.incorrect'))
-          expect(page).to have_css('#total_incorrect', text: '1')
         end
+        questions
+      }
+
+      scenario 'all questions are shuffled' do
+        expect(question_user_ids).not_to eq question_user_ids.sort
+      end
+
+      scenario 'all questions have each different users' do
+        expect(question_user_ids.uniq.size).to eq question_user_ids.size
       end
     end
   end

--- a/spec/features/quizees_spec.rb
+++ b/spec/features/quizees_spec.rb
@@ -26,7 +26,7 @@ feature 'クイズ', type: :feature do
 
   # FIXME: ビューのテストにしかなってないのでなおす
   feature 'クイズを進める' do
-    let!(:users) { FactoryGirl.create_list :user_profile, 5 }
+    let!(:users) { FactoryGirl.create_list :user_profile, 30 }
     let!(:question_user) { FactoryGirl.create :user_profile }
 
     before do
@@ -50,11 +50,30 @@ feature 'クイズ', type: :feature do
 
         expect(page).to have_content question_user.user.name
         expect(page).to have_content question_user.answer_name
+        expect(page).to have_content question_user.detail
         # expect(page).to have_content gender
         # expect(page).to have_content joined_year
         # expect(page).to have_content group_name
         # expect(page).to have_content project_name
-        expect(page).to have_content question_user.detail
+      end
+
+      feature 'to many questions continuity' do
+        let(:question_user_ids) {
+          questions = []
+
+          10.times do
+            questions.push find('#question_image')['data-user-id'].to_i
+
+            fill_in 'answer_name', with: question_user.answer_name
+            click_button I18n.t('quiz.question.submit')
+            click_button I18n.t('quiz.result.next')
+          end
+          questions
+        }
+
+        scenario 'questions are shuffled' do
+          expect(question_user_ids).not_to eq question_user_ids.sort
+        end
       end
 
       context '正解だった場合' do


### PR DESCRIPTION
- 表題の不具合を修正した。
- 1人のユーザーが3連続で出題されてしまう不具合を修正した。
- クイズのテストをリファクタリングした。
# English

slack の #english 窓でアドバイスをいただいた。

![2015-10-02 14 46 32](https://cloud.githubusercontent.com/assets/13635059/10240247/74bba282-6914-11e5-9319-bbfb353e8ffc.png)
