### PR TITLE
漢字をひらがなに変換して、ひらがなでの回答を受け付けるようにする

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,17 @@ rvm:
   - 2.2.2
 bundler_args: --without development --deployment
 cache: bundler
-sudo: false
+sudo: true
 before_script:
   - cp config/database.travis.yml config/database.yml
   - bundle exec rake db:create
   - bundle exec rake db:migrate
 script:
+  - wget http://kakasi.namazu.org/stable/kakasi-2.3.6.tar.gz
+  - tar zxfv kakasi-2.3.6.tar.gz
+  - cd kakasi-2.3.6/
+  - ./configure
+  - make
+  - sudo make install
+
   - bundle exec rspec spec

--- a/app/models/answer_match.rb
+++ b/app/models/answer_match.rb
@@ -1,0 +1,66 @@
+class AnswerMatch
+  require 'nkf'
+
+  class << self
+    # 氏名等をゆるく判定 (最初か最後の文字が、ある程度一致したらマッチ)
+    def with_fuzzy_on_full_name(answer_text, full_name)
+      return false if answer_text.blank? || full_name.blank?
+
+      !!(
+      katakana_to_hiragana(answer_text) == full_name ||
+      katakana_to_hiragana(answer_text).match("^#{full_name[0..1]}") ||
+      katakana_to_hiragana(answer_text).match("#{full_name[-2..-1]}$")
+      )
+    end
+
+    # カタカナとひらがな / 大文字と小文字 を揃えて判定
+    def with_convert(answer_text, name)
+      return false if answer_text.blank? || name.blank?
+
+      katakana_to_hiragana(name) == katakana_to_hiragana(answer_text)
+    end
+
+    # 漢字氏名を自然言語処理でひらがなに変えて判定
+    def with_natural_language_on_full_name(answer_text, full_name)
+      return false if answer_text.blank? || full_name.blank?
+
+      hiragana_full_name = kanji_to_hiragana(full_name)
+
+      with_convert(answer_text, hiragana_full_name) ||
+      on_last_name(answer_text, hiragana_full_name) ||
+      on_first_name(answer_text, hiragana_full_name)
+    end
+
+    def on_last_name(answer_text, full_name)
+      return false if answer_text.blank? || full_name.blank?
+
+      if full_name.length.even?
+        match_length = ((full_name.length+1)/2)-1
+      else
+        match_length = ((full_name.length+1)/2)-2
+      end
+
+      !!(katakana_to_hiragana(answer_text).match("^#{full_name[0..match_length]}"))
+    end
+
+    def on_first_name(answer_text, full_name)
+      return false if answer_text.blank? || full_name.blank?
+
+      if full_name.length.even?
+        match_length = (-(full_name.length)/2)
+      else
+        match_length = (-(full_name.length)/2)+1
+      end
+
+      !!(katakana_to_hiragana(answer_text).match("#{full_name[match_length..-1]}$"))
+    end
+
+    def kanji_to_hiragana(text)
+      `printf '#{text}' | nkf -e | kakasi -JH | nkf -w`
+    end
+
+    def katakana_to_hiragana(text)
+      NKF.nkf("--hiragana -w", text)
+    end
+  end
+end

--- a/app/models/answer_match.rb
+++ b/app/models/answer_match.rb
@@ -17,7 +17,7 @@ class AnswerMatch
     def with_convert(answer_text, name)
       return false if answer_text.blank? || name.blank?
 
-      katakana_to_hiragana(name) == katakana_to_hiragana(answer_text)
+      katakana_to_hiragana(name).upcase == katakana_to_hiragana(answer_text).upcase
     end
 
     # 漢字氏名を自然言語処理でひらがなに変えて判定

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -58,8 +58,11 @@ class Quiz
   end
 
   def self.correct?(user_profile, answer_text)
+    answer_text.strip!
+    converted_answer_text = NKF.nkf("--hiragana -w", answer_text)
+
     # ユーザーが決めた正解文字列での判定 (ひらがな入力でもカタカナ入力でも等しく判定する)
-    if NKF.nkf("--hiragana -w", user_profile.answer_name) == NKF.nkf("--hiragana -w", answer_text)
+    if NKF.nkf("--hiragana -w", user_profile.answer_name) == converted_answer_text
       return true
     # Google認証情報の氏名使って判定 (完全一致)
     elsif user_profile.user.name == answer_text
@@ -70,6 +73,19 @@ class Quiz
     # Google認証情報の氏名を使って、名前をゆるく判定 (ラストの二文字が一致すれば正解)
     elsif answer_text.match("#{user_profile.user.name[-2..-1]}$")
       return true
+    # Google認証情報の漢字氏名を、ひらがなに自動変換して判定する
+    else
+      hiragana_full_name = `printf '#{user_profile.name}' | nkf -e | kakasi -JH | nkf -w`
+      last_name_length = ((hiragana_full_name.length+1)/2)-1
+      first_name_length = (-(hiragana_full_name.length)/2)+1
+
+      if converted_answer_text == hiragana_full_name
+        return true
+      elsif converted_answer_text.match("^#{hiragana_full_name[0..last_name_length]}")
+        return true
+      elsif converted_answer_text.match("#{hiragana_full_name[first_name_length..-1]}$")
+        return true
+      end
     end
     false
   end

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -59,23 +59,23 @@ class Quiz
 
   class << self
     def correct?(user_profile, answer_text)
-      answer_text.strip!
-      return false if answer_text.blank?
+      striped_answer_text = answer_text.strip
+      return false if striped_answer_text.blank?
 
-      converting_match(answer_text, user_profile.answer_name) ||
-      fazzy_match(answer_text, user_profile.name) ||
-      natural_language_match(answer_text, user_profile.name)
+      converting_match(striped_answer_text, user_profile.answer_name) ||
+      fazzy_match(striped_answer_text, user_profile.name) ||
+      natural_language_match(striped_answer_text, user_profile.name)
     end
 
     # 氏名等をゆるく判定 (最初か最後の文字が、ある程度一致したらマッチ)
     def fazzy_match(answer_text, full_name)
       return false if answer_text.blank? || full_name.blank?
 
-      (
+      !!(
       katakana_to_hiragana(answer_text) == full_name ||
       katakana_to_hiragana(answer_text).match("^#{full_name[0..1]}") ||
       katakana_to_hiragana(answer_text).match("#{full_name[-2..-1]}$")
-      ) && true || false
+      )
     end
 
     def converting_match(answer_text, name)
@@ -99,14 +99,14 @@ class Quiz
       return false if answer_text.blank? || full_name.blank?
 
       last_name_length = ((full_name.length+1)/2)-1
-      (katakana_to_hiragana(answer_text).match("^#{full_name[0..last_name_length]}") && true) || false
+      !!(katakana_to_hiragana(answer_text).match("^#{full_name[0..last_name_length]}"))
     end
 
     def first_name_match(answer_text, full_name)
       return false if answer_text.blank? || full_name.blank?
 
       first_name_length = (-(full_name.length)/2)+1
-      (katakana_to_hiragana(answer_text).match("#{full_name[first_name_length..-1]}$") && true) || false
+      !!(katakana_to_hiragana(answer_text).match("#{full_name[first_name_length..-1]}$"))
     end
 
     def katakana_to_hiragana(answer_text)

--- a/spec/models/answer_match_spec.rb
+++ b/spec/models/answer_match_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe AnswerMatch, type: :model do
+  describe '.with_convert' do
+    subject { AnswerMatch.with_convert(answer, correct_answer) }
+
+    context 'when correct answer is hiragana' do
+      let(:correct_answer) { 'はんざわ' }
+      let(:answer) { 'ハンザワ' }
+
+      it 'katakana answer matches' do
+        expect(subject).to eq true
+      end
+    end
+  end
+
+  describe '.on_last_name' do
+    subject { AnswerMatch.on_last_name(answer, correct_answer) }
+
+    context 'when correct answer has 3 characters' do
+      let(:correct_answer) { '上戸彩' }
+
+      describe 'answer matches' do
+        describe 'with aenough character' do
+          let(:answer) { '上' }
+          example { expect(subject).to eq true }
+        end
+      end
+    end
+
+    context 'when correct answer has 4 characters' do
+      let(:correct_answer) { '半沢直樹' }
+
+      describe 'answer matches' do
+        describe 'with correct last name' do
+          let(:answer) { '半沢' }
+          example { expect(subject).to eq true }
+        end
+      end
+
+      describe 'answer does not matches' do
+        describe 'with a not enough character' do
+          let(:answer) { '半' }
+          example { expect(subject).to eq false }
+        end
+      end
+    end
+
+    context 'when correct answer has 5 characters' do
+      let(:correct_answer) { '古畑任三郎' }
+
+      describe 'answer matches' do
+        describe 'with enough and correct characters' do
+          let(:answer) { '古畑' }
+          example { expect(subject).to eq true }
+        end
+      end
+    end
+  end
+
+  describe '.on_first_name' do
+    subject { AnswerMatch.on_first_name(answer, correct_answer) }
+
+    context 'when correct answer has 3 characters' do
+      let(:correct_answer) { '上戸彩' }
+
+      describe 'answer matches' do
+        describe 'with enought and correct characters' do
+          let(:answer) { '彩' }
+          example { expect(subject).to eq true }
+        end
+      end
+    end
+
+    context 'when correct answer has 4 characters' do
+      let(:correct_answer) { '半沢直樹' }
+
+      describe 'answer matches' do
+        describe 'with enought and correct characters' do
+          let(:answer) { '直樹' }
+          example { expect(subject).to eq true }
+        end
+      end
+
+      describe 'answer does not matches' do
+        describe 'with a not enough character' do
+          let(:answer) { '樹' }
+          example { expect(subject).to eq false }
+        end
+      end
+    end
+
+    context 'when correct answer has 5 characters' do
+      let(:correct_answer) { '古畑任三郎' }
+
+      describe 'answer matches' do
+        describe 'with enough and correct characters' do
+          let(:answer) { '三郎' }
+          example { expect(subject).to eq true }
+        end
+      end
+    end
+  end
+
+  describe '.kanji_to_hiragana' do
+    subject { AnswerMatch.kanji_to_hiragana(kanji) }
+
+    let(:kanji) { '半沢直樹' }
+    let(:hiragana) { 'はんざわなおき' }
+
+    it 'kanji was converted to hiragana' do
+      expect(subject).to eq hiragana
+    end
+  end
+end

--- a/spec/models/answer_match_spec.rb
+++ b/spec/models/answer_match_spec.rb
@@ -4,6 +4,15 @@ RSpec.describe AnswerMatch, type: :model do
   describe '.with_convert' do
     subject { AnswerMatch.with_convert(answer, correct_answer) }
 
+    context 'when correct answer is downcase' do
+      let(:correct_answer) { 'John' }
+      let(:answer) { 'john' }
+
+      it 'upcase answer matches' do
+        expect(subject).to eq true
+      end
+    end
+
     context 'when correct answer is hiragana' do
       let(:correct_answer) { 'はんざわ' }
       let(:answer) { 'ハンザワ' }

--- a/spec/models/quiz_spec.rb
+++ b/spec/models/quiz_spec.rb
@@ -2,23 +2,78 @@ require 'rails_helper'
 
 RSpec.describe Quiz, type: :model do
   describe '.correct?' do
-    let(:user_profiles) { FactoryGirl.create_list :user_profile, 5 }
-    let(:answer_user_profile) { user_profiles.sample }
+    describe 'Standard name' do
+      let(:question_user_profile) { FactoryGirl.create :user_profile }
 
-    it 'answer name is matched' do
-      expect(Quiz.correct?(answer_user_profile, answer_user_profile.user.name)).to be true
+      describe 'is matched' do
+        it 'at answer name' do
+          expect(Quiz.correct?(question_user_profile, question_user_profile.user.name)).to be true
+        end
+
+        it 'at Google full name' do
+          expect(Quiz.correct?(question_user_profile, question_user_profile.answer_name)).to be true
+        end
+
+        it 'at last name' do
+          expect(Quiz.correct?(question_user_profile, question_user_profile.user.name[0..1])).to be true
+        end
+
+        it 'at first name' do
+          expect(Quiz.correct?(question_user_profile, question_user_profile.user.name[-2..-1])).to be true
+        end
+      end
     end
 
-    it 'Google full name is matched' do
-      expect(Quiz.correct?(answer_user_profile, answer_user_profile.answer_name)).to be true
-    end
+    describe 'Japanese name' do
+      let(:question_user) { FactoryGirl.create :user, :with_user_profile, name: '半沢直樹' }
 
-    it 'last name is matched (loosely judge by regular expression)' do
-      expect(Quiz.correct?(answer_user_profile, answer_user_profile.user.name[0..1])).to be true
-    end
+      describe 'is matched' do
+        describe 'on hiragana' do
+          it 'at full name ' do
+            expect(Quiz.correct?(question_user.user_profile, 'はんざわなおき')).to be true
+          end
 
-    it 'first name is matched (loosely judge by regular expression)' do
-      expect(Quiz.correct?(answer_user_profile, answer_user_profile.user.name[-2..-1])).to be true
+          it 'at full name with spece' do
+            expect(Quiz.correct?(question_user.user_profile, 'はんざわ なおき')).to be true
+          end
+
+          it 'at last name' do
+            expect(Quiz.correct?(question_user.user_profile, 'はんざわ')).to be true
+          end
+
+          it 'at first name' do
+            expect(Quiz.correct?(question_user.user_profile, 'なおき')).to be true
+          end
+        end
+
+        describe 'on katakana' do
+          it 'at full name ' do
+            expect(Quiz.correct?(question_user.user_profile, 'ハンザワナオキ')).to be true
+          end
+
+          it 'at last name' do
+            expect(Quiz.correct?(question_user.user_profile, 'ハンザワ')).to be true
+          end
+
+          it 'at first name' do
+            expect(Quiz.correct?(question_user.user_profile, 'ナオキ')).to be true
+          end
+        end
+      end
+
+      describe 'is not matched' do
+        it 'at last name' do
+          expect(Quiz.correct?(question_user.user_profile, 'はん')).to be false
+        end
+
+        it 'at first name' do
+          expect(Quiz.correct?(question_user.user_profile, 'おき')).to be false
+        end
+
+        it 'at imcompleted name' do
+          expect(Quiz.correct?(question_user.user_profile, 'んざわなお')).to be false
+        end
+      end
     end
   end
 end

--- a/spec/models/quiz_spec.rb
+++ b/spec/models/quiz_spec.rb
@@ -2,76 +2,85 @@ require 'rails_helper'
 
 RSpec.describe Quiz, type: :model do
   describe '.correct?' do
-    describe 'Standard name' do
+    context 'When correct answer is English' do
       let(:question_user_profile) { FactoryGirl.create :user_profile }
 
-      describe 'is matched' do
-        it 'at answer name' do
+      describe 'Answer matches' do
+        example 'to free style correct answer' do
           expect(Quiz.correct?(question_user_profile, question_user_profile.user.name)).to be true
         end
 
-        it 'at Google full name' do
+        example 'with full name' do
           expect(Quiz.correct?(question_user_profile, question_user_profile.answer_name)).to be true
         end
 
-        it 'at last name' do
+        example 'with last name' do
           expect(Quiz.correct?(question_user_profile, question_user_profile.user.name[0..1])).to be true
         end
 
-        it 'at first name' do
+        example 'with first name' do
           expect(Quiz.correct?(question_user_profile, question_user_profile.user.name[-2..-1])).to be true
+        end
+      end
+
+      describe 'Answer does not matches' do
+        example 'with empty text' do
+          expect(Quiz.correct?(question_user_profile, '')).to be false
+        end
+
+        example 'with space all text' do
+          expect(Quiz.correct?(question_user_profile, ' ')).to be false
         end
       end
     end
 
-    describe 'Japanese name' do
+    context 'When correct answer is Japanese' do
       let(:question_user) { FactoryGirl.create :user, :with_user_profile, name: '半沢直樹' }
 
-      describe 'is matched' do
-        describe 'on hiragana' do
-          it 'at full name ' do
+      describe 'Hiragana answer' do
+        describe 'Matches' do
+          example 'with full name ' do
             expect(Quiz.correct?(question_user.user_profile, 'はんざわなおき')).to be true
           end
 
-          it 'at full name with spece' do
+          example 'with has space full name' do
             expect(Quiz.correct?(question_user.user_profile, 'はんざわ なおき')).to be true
           end
 
-          it 'at last name' do
+          example 'with last name' do
             expect(Quiz.correct?(question_user.user_profile, 'はんざわ')).to be true
           end
 
-          it 'at first name' do
+          example 'with first name' do
             expect(Quiz.correct?(question_user.user_profile, 'なおき')).to be true
           end
         end
 
-        describe 'on katakana' do
-          it 'at full name ' do
-            expect(Quiz.correct?(question_user.user_profile, 'ハンザワナオキ')).to be true
+        describe 'Does not matches' do
+          example 'with not enough length name.' do
+            expect(Quiz.correct?(question_user.user_profile, 'はん')).to be false
+            expect(Quiz.correct?(question_user.user_profile, 'おき')).to be false
           end
 
-          it 'at last name' do
-            expect(Quiz.correct?(question_user.user_profile, 'ハンザワ')).to be true
-          end
-
-          it 'at first name' do
-            expect(Quiz.correct?(question_user.user_profile, 'ナオキ')).to be true
+          example 'with imcompleted name.' do
+            expect(Quiz.correct?(question_user.user_profile, 'んざわなお')).to be false
           end
         end
       end
 
-      describe 'is not matched' do
-        it 'at last name' do
-          expect(Quiz.correct?(question_user.user_profile, 'はん')).to be false
-        end
+      describe 'Katakana answer' do
+        describe 'Matches' do
+          example 'with full name ' do
+            expect(Quiz.correct?(question_user.user_profile, 'ハンザワナオキ')).to be true
+          end
 
-        it 'at first name' do
-          expect(Quiz.correct?(question_user.user_profile, 'おき')).to be false
-        end
+          example 'with last name' do
+            expect(Quiz.correct?(question_user.user_profile, 'ハンザワ')).to be true
+          end
 
-        it 'at imcompleted name' do
-          expect(Quiz.correct?(question_user.user_profile, 'んざわなお')).to be false
+          example 'with first name' do
+            expect(Quiz.correct?(question_user.user_profile, 'ナオキ')).to be true
+          end
         end
       end
     end


### PR DESCRIPTION
- convert kanji full name to hiragana. ( kanji is from Google API data )
- use system call , kakasi with nkf
  - http://kakasi.namazu.org/stable/
  - http://kzy52.com/entry/2014/07/17/225448
